### PR TITLE
(Claude) Zenn同期ワークフローの修正

### DIFF
--- a/.github/workflows/sync-zenn.yml
+++ b/.github/workflows/sync-zenn.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           repository: Rioto3/zenn-contents
           path: zenn-contents
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.ZENN_PORTFOLIO_SYNC_TOKEN }}
       
       - name: Checkout Portfolio repository
         uses: actions/checkout@v3
@@ -26,7 +26,7 @@ jobs:
           repository: Rioto3/rioto3-portfolio-vercel-nextjs-tina
           path: portfolio
           ref: drafts
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.ZENN_PORTFOLIO_SYNC_TOKEN }}
       
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -39,12 +39,126 @@ jobs:
           npm init -y
           npm install js-yaml gray-matter
       
+      - name: Create converter script
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/scripts
+          cat > $GITHUB_WORKSPACE/scripts/convert-md-to-mdx.js << 'EOF'
+          const fs = require('fs');
+          const path = require('path');
+          const yaml = require('js-yaml');
+          const matter = require('gray-matter');
+
+          function convertMdToMdx(srcPath, destPath, options = {}) {
+            const {
+              defaultAuthor = 'content/authors/Rioto3.md',
+              defaultHeroImg = '', 
+              generateExcerpt = true,
+            } = options;
+
+            const mdContent = fs.readFileSync(srcPath, 'utf8');
+            const { data: frontMatter, content } = matter(mdContent);
+            
+            const mdxFrontMatter = {
+              tags: frontMatter.topics || [],
+              title: frontMatter.title,
+              heroImg: defaultHeroImg,
+              excerpt: generateExcerpt 
+                ? generateExcerptFromContent(content, frontMatter.title) 
+                : frontMatter.title,
+              author: defaultAuthor,
+              date: options.date || new Date().toISOString(),
+            };
+            
+            const mdxContent = `---
+${yaml.dump(mdxFrontMatter)}---
+
+${content}`;
+            
+            const destDir = path.dirname(destPath);
+            if (!fs.existsSync(destDir)) {
+              fs.mkdirSync(destDir, { recursive: true });
+            }
+            
+            fs.writeFileSync(destPath, mdxContent, 'utf8');
+            
+            return {
+              srcPath,
+              destPath,
+              frontMatter: mdxFrontMatter
+            };
+          }
+
+          function generateExcerptFromContent(content, title) {
+            const paragraphs = content.split('\n\n').filter(p => p.trim() && !p.startsWith('#'));
+            
+            if (paragraphs.length === 0) {
+              return title;
+            }
+            
+            let excerpt = paragraphs[0].trim();
+            
+            excerpt = excerpt
+              .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+              .replace(/[*_]{1,2}([^*_]+)[*_]{1,2}/g, '$1')
+              .replace(/`([^`]+)`/g, '$1');
+            
+            if (excerpt.length > 150) {
+              excerpt = excerpt.substring(0, 147) + '...';
+            }
+            
+            return excerpt;
+          }
+
+          function main() {
+            const sourceDir = process.env.SOURCE_DIR || './zenn-contents/articles';
+            const destDir = process.env.DEST_DIR || './portfolio/content/posts';
+            const specificFile = process.env.SPECIFIC_FILE || '';
+            
+            let sourceFiles;
+            
+            if (specificFile) {
+              // 特定のファイルのみ処理
+              if (fs.existsSync(path.join(sourceDir, specificFile))) {
+                sourceFiles = [specificFile];
+              } else {
+                console.error(`指定されたファイル ${specificFile} は存在しません`);
+                process.exit(1);
+              }
+            } else {
+              // すべてのファイルを処理
+              sourceFiles = fs.readdirSync(sourceDir)
+                .filter(file => file.endsWith('.md') && !file.startsWith('_'));
+            }
+            
+            console.log(`Converting ${sourceFiles.length} files from ${sourceDir} to ${destDir}`);
+            
+            for (const file of sourceFiles) {
+              const srcPath = path.join(sourceDir, file);
+              const destFileName = file.replace(/\.md$/, '.mdx');
+              const destPath = path.join(destDir, destFileName);
+              
+              try {
+                const result = convertMdToMdx(srcPath, destPath, {
+                  date: new Date().toISOString(),
+                  defaultHeroImg: '/uploads/default-hero.png',
+                });
+                
+                console.log(`✅ Converted: ${result.srcPath} -> ${result.destPath}`);
+              } catch (error) {
+                console.error(`❌ Error converting ${srcPath}: ${error.message}`);
+              }
+            }
+          }
+
+          main();
+          EOF
+      
       - name: Run converter script
         run: |
           export SOURCE_DIR="$GITHUB_WORKSPACE/zenn-contents/articles"
           export DEST_DIR="$GITHUB_WORKSPACE/portfolio/content/posts"
           export SPECIFIC_FILE="${{ github.event.inputs.specific_file }}"
-          node $GITHUB_WORKSPACE/portfolio/scripts/convert-md-to-mdx.js
+          node $GITHUB_WORKSPACE/scripts/convert-md-to-mdx.js
       
       - name: Commit changes to portfolio repo
         run: |


### PR DESCRIPTION
## 概要
Zenn記事をポートフォリオサイトに同期するワークフローを修正しました。

## 修正内容
- 変換スクリプトをワークフロー内で直接生成するよう修正
- シークレット名を`ZENN_PORTFOLIO_SYNC_TOKEN`に変更
- 不要なファイル依存関係を解消

## 設定方法
1. リポジトリの Settings > Secrets and variables > Actions で以下を設定:
   - 名前: `ZENN_PORTFOLIO_SYNC_TOKEN`
   - 値: GitHubのPersonal Access Token (repo権限付き)

## 使用方法
1. Actions タブから「Sync Zenn to Portfolio」ワークフローを実行
2. 必要に応じて特定ファイルのパラメータを指定
3. 変換されたMDXファイルは drafts ブランチに追加されます