### PR TITLE
(Claude) Zenn同期ワークフロー - 別ファイル方式で解決

### DIFF
--- a/.github/scripts/convert-md-to-mdx.js
+++ b/.github/scripts/convert-md-to-mdx.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const matter = require('gray-matter');
+
+function convertMdToMdx(srcPath, destPath, options = {}) {
+  const {
+    defaultAuthor = 'content/authors/Rioto3.md',
+    defaultHeroImg = '', 
+    generateExcerpt = true,
+  } = options;
+
+  const mdContent = fs.readFileSync(srcPath, 'utf8');
+  const { data: frontMatter, content } = matter(mdContent);
+  
+  const mdxFrontMatter = {
+    tags: frontMatter.topics || [],
+    title: frontMatter.title,
+    heroImg: defaultHeroImg,
+    excerpt: generateExcerpt 
+      ? generateExcerptFromContent(content, frontMatter.title) 
+      : frontMatter.title,
+    author: defaultAuthor,
+    date: options.date || new Date().toISOString(),
+  };
+  
+  const mdxContent = `---
+${yaml.dump(mdxFrontMatter)}---
+
+${content}`;
+  
+  const destDir = path.dirname(destPath);
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+  
+  fs.writeFileSync(destPath, mdxContent, 'utf8');
+  
+  return {
+    srcPath,
+    destPath,
+    frontMatter: mdxFrontMatter
+  };
+}
+
+function generateExcerptFromContent(content, title) {
+  const paragraphs = content.split('\n\n').filter(p => p.trim() && !p.startsWith('#'));
+  
+  if (paragraphs.length === 0) {
+    return title;
+  }
+  
+  let excerpt = paragraphs[0].trim();
+  
+  excerpt = excerpt
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[*_]{1,2}([^*_]+)[*_]{1,2}/g, '$1')
+    .replace(/`([^`]+)`/g, '$1');
+  
+  if (excerpt.length > 150) {
+    excerpt = excerpt.substring(0, 147) + '...';
+  }
+  
+  return excerpt;
+}
+
+function main() {
+  const sourceDir = process.env.SOURCE_DIR || './zenn-contents/articles';
+  const destDir = process.env.DEST_DIR || './portfolio/content/posts';
+  const specificFile = process.env.SPECIFIC_FILE || '';
+  
+  let sourceFiles;
+  
+  if (specificFile) {
+    // 特定のファイルのみ処理
+    if (fs.existsSync(path.join(sourceDir, specificFile))) {
+      sourceFiles = [specificFile];
+    } else {
+      console.error(`指定されたファイル ${specificFile} は存在しません`);
+      process.exit(1);
+    }
+  } else {
+    // すべてのファイルを処理
+    sourceFiles = fs.readdirSync(sourceDir)
+      .filter(file => file.endsWith('.md') && !file.startsWith('_'));
+  }
+  
+  console.log(`Converting ${sourceFiles.length} files from ${sourceDir} to ${destDir}`);
+  
+  for (const file of sourceFiles) {
+    const srcPath = path.join(sourceDir, file);
+    const destFileName = file.replace(/\.md$/, '.mdx');
+    const destPath = path.join(destDir, destFileName);
+    
+    try {
+      const result = convertMdToMdx(srcPath, destPath, {
+        date: new Date().toISOString(),
+        defaultHeroImg: '/uploads/default-hero.png',
+      });
+      
+      console.log(`✅ Converted: ${result.srcPath} -> ${result.destPath}`);
+    } catch (error) {
+      console.error(`❌ Error converting ${srcPath}: ${error.message}`);
+    }
+  }
+}
+
+main();

--- a/.github/workflows/sync-zenn.yml
+++ b/.github/workflows/sync-zenn.yml
@@ -39,14 +39,13 @@ jobs:
           npm init -y
           npm install js-yaml gray-matter
       
-      - name: Create converter script
-        run: echo "const fs = require('fs'); const path = require('path'); const yaml = require('js-yaml'); const matter = require('gray-matter'); function convertMdToMdx(srcPath, destPath, options = {}) { const { defaultAuthor = 'content/authors/Rioto3.md', defaultHeroImg = '', generateExcerpt = true, } = options; const mdContent = fs.readFileSync(srcPath, 'utf8'); const { data: frontMatter, content } = matter(mdContent); const mdxFrontMatter = { tags: frontMatter.topics || [], title: frontMatter.title, heroImg: defaultHeroImg, excerpt: generateExcerpt ? generateExcerptFromContent(content, frontMatter.title) : frontMatter.title, author: defaultAuthor, date: options.date || new Date().toISOString(), }; const mdxContent = \`---\n\${yaml.dump(mdxFrontMatter)}---\n\n\${content}\`; const destDir = path.dirname(destPath); if (!fs.existsSync(destDir)) { fs.mkdirSync(destDir, { recursive: true }); } fs.writeFileSync(destPath, mdxContent, 'utf8'); return { srcPath, destPath, frontMatter: mdxFrontMatter }; } function generateExcerptFromContent(content, title) { const paragraphs = content.split('\n\n').filter(p => p.trim() && !p.startsWith('#')); if (paragraphs.length === 0) { return title; } let excerpt = paragraphs[0].trim(); excerpt = excerpt.replace(/\\[([^\\]]+)\\]\\([^)]+\\)/g, '$1').replace(/[*_]{1,2}([^*_]+)[*_]{1,2}/g, '$1').replace(/\`([^\`]+)\`/g, '$1'); if (excerpt.length > 150) { excerpt = excerpt.substring(0, 147) + '...'; } return excerpt; } function main() { const sourceDir = process.env.SOURCE_DIR || './zenn-contents/articles'; const destDir = process.env.DEST_DIR || './portfolio/content/posts'; const specificFile = process.env.SPECIFIC_FILE || ''; let sourceFiles; if (specificFile) { if (fs.existsSync(path.join(sourceDir, specificFile))) { sourceFiles = [specificFile]; } else { console.error(\`指定されたファイル \${specificFile} は存在しません\`); process.exit(1); } } else { sourceFiles = fs.readdirSync(sourceDir).filter(file => file.endsWith('.md') && !file.startsWith('_')); } console.log(\`Converting \${sourceFiles.length} files from \${sourceDir} to \${destDir}\`); for (const file of sourceFiles) { const srcPath = path.join(sourceDir, file); const destFileName = file.replace(/\\.md$/, '.mdx'); const destPath = path.join(destDir, destFileName); try { const result = convertMdToMdx(srcPath, destPath, { date: new Date().toISOString(), defaultHeroImg: '/uploads/default-hero.png', }); console.log(\`✅ Converted: \${result.srcPath} -> \${result.destPath}\`); } catch (error) { console.error(\`❌ Error converting \${srcPath}: \${error.message}\`); } } } main();" > $GITHUB_WORKSPACE/scripts/convert-md-to-mdx.js
-      
       - name: Run converter script
         run: |
           export SOURCE_DIR="$GITHUB_WORKSPACE/zenn-contents/articles"
           export DEST_DIR="$GITHUB_WORKSPACE/portfolio/content/posts"
           export SPECIFIC_FILE="${{ github.event.inputs.specific_file }}"
+          mkdir -p $GITHUB_WORKSPACE/scripts
+          cp $GITHUB_WORKSPACE/portfolio/.github/scripts/convert-md-to-mdx.js $GITHUB_WORKSPACE/scripts/
           node $GITHUB_WORKSPACE/scripts/convert-md-to-mdx.js
       
       - name: Commit changes to portfolio repo


### PR DESCRIPTION
## 概要
Zenn同期ワークフロー内のYAML構文エラーを根本的に解決するため、スクリプトを別ファイルに分離しました。

## 変更内容
1. スクリプトを `.github/scripts/convert-md-to-mdx.js` として分離
2. ワークフローファイルをシンプル化し、別ファイル参照方式に変更
3. YAMLヒアドキュメント構文の問題を完全に回避

## メリット
- より保守性の高い設計
- エラーが発生しにくい構造
- スクリプトの単体テストが容易

## 設定方法
引き続き、リポジトリの Settings > Secrets and variables > Actions で以下を設定してください:
- 名前: `ZENN_PORTFOLIO_SYNC_TOKEN`
- 値: GitHubのPersonal Access Token (repo権限付き)